### PR TITLE
Data Class Handling Improvements

### DIFF
--- a/src/main/kotlin/dev/aga/sfm/KReflectionService.kt
+++ b/src/main/kotlin/dev/aga/sfm/KReflectionService.kt
@@ -1,11 +1,39 @@
 package dev.aga.sfm
 
 import org.simpleflatmapper.reflect.DefaultReflectionService
+import org.simpleflatmapper.reflect.InstantiatorDefinition
 import org.simpleflatmapper.reflect.InstantiatorFactory
 import org.simpleflatmapper.reflect.asm.AsmFactory
+import java.lang.reflect.Member
+import java.lang.reflect.Type
+import kotlin.reflect.KClass
 
 class KReflectionService(asmFactory: AsmFactory?) : DefaultReflectionService(asmFactory) {
     override fun getInstantiatorFactory(): InstantiatorFactory {
         return KInstantiatorFactory(this)
+    }
+
+    override fun extractInstantiator(target: Type, extraInstantiator: Member?): MutableList<InstantiatorDefinition> {
+        toKClass(target)?.let {
+            return mutableListOf(KConstructorInstantiatorDefinition(it))
+        }
+
+        return super.extractInstantiator(target, extraInstantiator)
+    }
+
+    companion object {
+        /**
+         * Gets the [KClass] for the provided [Type] if we are able to support it.
+         *
+         * @param target the [Type] to fetch the [KClass] for
+         * @return the [KClass] for the [target] if we can support it, otherwise ```null```
+         */
+        internal fun toKClass(target: Type): KClass<*>? {
+            val targetClazz = Class.forName(target.typeName).kotlin
+            if (targetClazz.isData) {
+                return targetClazz
+            }
+            return null
+        }
     }
 }

--- a/src/test/java/dev/aga/sfm/model/MyPojo.java
+++ b/src/test/java/dev/aga/sfm/model/MyPojo.java
@@ -4,6 +4,15 @@ public class MyPojo {
     private int id;
     private String name;
 
+    public MyPojo() {
+        this(0, null);
+    }
+
+    public MyPojo(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public int getId() {
         return id;
     }

--- a/src/test/kotlin/dev/aga/sfm/KConstructorBiInstantiatorTest.kt
+++ b/src/test/kotlin/dev/aga/sfm/KConstructorBiInstantiatorTest.kt
@@ -49,7 +49,6 @@ internal class KConstructorBiInstantiatorTest {
         assertThat(actual).isEqualTo(expected)
     }
 
-
     private fun makeBiFunction(ret: Any): BiFunction<Any, Any, *> {
         return BiFunction<Any, Any, Any> { _, _ -> ret }
     }

--- a/src/test/kotlin/dev/aga/sfm/KInstantiatorFactoryTest.kt
+++ b/src/test/kotlin/dev/aga/sfm/KInstantiatorFactoryTest.kt
@@ -1,0 +1,53 @@
+package dev.aga.sfm
+
+import dev.aga.sfm.model.KotlinDataClass
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.simpleflatmapper.reflect.impl.InjectConstructorBiInstantiator
+import org.simpleflatmapper.reflect.instantiator.ExecutableInstantiatorDefinition
+import kotlin.reflect.javaType
+import kotlin.reflect.jvm.javaConstructor
+import kotlin.reflect.typeOf
+
+internal class KInstantiatorFactoryTest {
+    @OptIn(ExperimentalStdlibApi::class)
+    @Test
+    internal fun `test getBiInstantiator checks for KConsturcotrInstantiatorDefinition first`() {
+        val reflectionService = KReflectionService(null)
+        val factory = reflectionService.instantiatorFactory
+        val def = KConstructorInstantiatorDefinition(KotlinDataClass::class)
+        val badDef = ExecutableInstantiatorDefinition(def.ctor.javaConstructor, *def.parameters)
+        val biInstantiator =
+            factory.getBiInstantiator<Any, Any, KotlinDataClass>(
+                typeOf<KotlinDataClass>().javaType,
+                Any::class.java,
+                Any::class.java,
+                listOf(badDef, def),
+                mapOf(),
+                false,
+                true
+            )
+        assertThat(biInstantiator).isInstanceOf(KConstructorBiInstantiator::class.java)
+    }
+
+    @OptIn(ExperimentalStdlibApi::class)
+    @Test
+    internal fun `test getBiInstantiator delegates to super if no KConstructorInstantiatorDefinition available`() {
+        val reflectionService = KReflectionService(null)
+        val factory = reflectionService.instantiatorFactory
+        val def = KConstructorInstantiatorDefinition(KotlinDataClass::class)
+        val notKDef = ExecutableInstantiatorDefinition(def.ctor.javaConstructor, *def.parameters)
+        val biInstantiator =
+            factory.getBiInstantiator<Any, Any, KotlinDataClass>(
+                typeOf<KotlinDataClass>().javaType,
+                Any::class.java,
+                Any::class.java,
+                listOf(notKDef),
+                mapOf(),
+                false,
+                true
+            )
+
+        assertThat(biInstantiator).isInstanceOf(InjectConstructorBiInstantiator::class.java)
+    }
+}

--- a/src/test/kotlin/dev/aga/sfm/KReflectionServiceTest.kt
+++ b/src/test/kotlin/dev/aga/sfm/KReflectionServiceTest.kt
@@ -8,13 +8,26 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.simpleflatmapper.reflect.instantiator.ExecutableInstantiatorDefinition
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
 import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
 
 internal class KReflectionServiceTest {
+
+    @ParameterizedTest
+    @MethodSource("testExtractInstantiatorProvider")
+    internal fun testExtractInstantiator(target: Type, expectedType: Class<*>, expectedSize: Int) {
+        val reflectionService = KReflectionService(null)
+        val actual = reflectionService.extractInstantiator(target)
+        assertThat(actual)
+            .hasSize(expectedSize)
+            .hasOnlyElementsOfType(expectedType)
+    }
+
     @ParameterizedTest
     @MethodSource("testToKClassProvider")
     internal fun testToKClass(target: Type, expected: KClass<*>?) {
@@ -23,14 +36,24 @@ internal class KReflectionServiceTest {
     }
 
     companion object {
+
+        @OptIn(ExperimentalStdlibApi::class)
+        @JvmStatic
+        private fun testExtractInstantiatorProvider(): List<Arguments> {
+            return listOf(
+                arguments(typeOf<KotlinDataClass>().javaType, KConstructorInstantiatorDefinition::class.java, 1),
+                arguments(typeOf<MyPojo>().javaType, ExecutableInstantiatorDefinition::class.java, 2)
+            )
+        }
+
         @OptIn(ExperimentalStdlibApi::class)
         @JvmStatic
         private fun testToKClassProvider(): List<Arguments> {
             return listOf(
-                Arguments.arguments(typeOf<MyPojo>().javaType, null),
-                Arguments.arguments(typeOf<KotlinClass>().javaType, null),
-                Arguments.arguments(typeOf<KotlinObject>().javaType, null),
-                Arguments.arguments(typeOf<KotlinDataClass>().javaType, KotlinDataClass::class)
+                arguments(typeOf<MyPojo>().javaType, null),
+                arguments(typeOf<KotlinClass>().javaType, null),
+                arguments(typeOf<KotlinObject>().javaType, null),
+                arguments(typeOf<KotlinDataClass>().javaType, KotlinDataClass::class)
             )
         }
     }

--- a/src/test/kotlin/dev/aga/sfm/KReflectionServiceTest.kt
+++ b/src/test/kotlin/dev/aga/sfm/KReflectionServiceTest.kt
@@ -8,19 +8,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.lang.reflect.Type
 import kotlin.reflect.KClass
 import kotlin.reflect.javaType
 import kotlin.reflect.typeOf
 
-internal class KInstantiatorFactoryTest {
-
+internal class KReflectionServiceTest {
     @ParameterizedTest
     @MethodSource("testToKClassProvider")
     internal fun testToKClass(target: Type, expected: KClass<*>?) {
-        val actual = KInstantiatorFactory.toKClass(target)
+        val actual = KReflectionService.toKClass(target)
         assertThat(actual).isEqualTo(expected)
     }
 
@@ -29,10 +27,10 @@ internal class KInstantiatorFactoryTest {
         @JvmStatic
         private fun testToKClassProvider(): List<Arguments> {
             return listOf(
-                arguments(typeOf<MyPojo>().javaType, null),
-                arguments(typeOf<KotlinClass>().javaType, null),
-                arguments(typeOf<KotlinObject>().javaType, null),
-                arguments(typeOf<KotlinDataClass>().javaType, KotlinDataClass::class)
+                Arguments.arguments(typeOf<MyPojo>().javaType, null),
+                Arguments.arguments(typeOf<KotlinClass>().javaType, null),
+                Arguments.arguments(typeOf<KotlinObject>().javaType, null),
+                Arguments.arguments(typeOf<KotlinDataClass>().javaType, KotlinDataClass::class)
             )
         }
     }


### PR DESCRIPTION
# Description
SFM seems to have trouble recognizing kotlin property names via reflection (even with `java-parameters` passed into the compiler). To help reduce false positives/matching, override `extractInstantiator` in `ReflectionService` to immediately return our `KConstructorInstantiatorDefinition` and circumvent the search for alternative instantiators